### PR TITLE
Update libinjection source repository and add SHA512 checksum

### DIFF
--- a/ports/libinjection/portfile.cmake
+++ b/ports/libinjection/portfile.cmake
@@ -1,7 +1,9 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libinjection
-    REF 85e252a28981d479822092bad235bb75beb7edfa
+    REPO libinjection/libinjection
+    REF  85e252a28981d479822092bad235bb75beb7edfa
+    SHA512 091a2d727915d01d3efaf60749dbff1513ab508c85ac11b1b5c936265a2a29bd9d3299b8afbe15295e4c55b53f3155620d6a318ff364938b861020c7e25915d4
+    HEAD_REF master
 )
 
 vcpkg_configure_make(

--- a/ports/libinjection/vcpkg.json
+++ b/ports/libinjection/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "libinjection",
   "version-string": "master",
   "description": "SQL / SQLI tokenizer parser analyzer.",
-  "homepage": "https://git.sr.ok/cpp-deps/libinjection",
+  "homepage": "https://github.com/libinjection/libinjection.git",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,7 +1,9 @@
-vcpkg_from_git(
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.gnome.org/
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libxml2.git
-    REF 954e851e1d8d1f4c1dfbdf043623b3c11a1c723c
+    REPO GNOME/libxml2
+    REF "v${VERSION}"
+    SHA512 3f2de446657bf3c23c92358ce8946f59253b9fcc09577b59eecaffdbd97e051659855c79f4882ee9f8841dd194b6bd5de2a8017691473b505e905b9dde6a1bc9
     HEAD_REF master
     PATCHES
         disable-docs.patch


### PR DESCRIPTION
Change the source repository for libinjection to GitHub and include a SHA512 checksum for verification. Update the homepage URL to point to the new repository.