### PR TITLE
Update version databases for hyperscan, libxml2, and libinjection

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,8 +1,9 @@
 # When this port is updated, the minizip port should be updated at the same time
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/zlib.git
-    REF 51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf
+    REPO madler/zlib
+    REF v${VERSION}
+    SHA512 8c9642495bafd6fad4ab9fb67f09b268c69ff9af0f4f20cf15dfc18852ff1f312bd8ca41de761b3f8d8e90e77d79f2ccacd3d4c5b19e475ecf09d021fdfe9088
     HEAD_REF master
     PATCHES
         0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch

--- a/versions/h-/hyperscan.json
+++ b/versions/h-/hyperscan.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5348a35987ae7122d5e85cf0d06d10cbe396c13c",
+      "git-tree": "a06885f259dadb6d54b36d6ab1a40d0b1328a0d6",
       "version": "5.4.2",
       "port-version": 1
     },

--- a/versions/l-/libinjection.json
+++ b/versions/l-/libinjection.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "6cd629e3cf8bded789376fa1837628fb86f636c3",
+      "git-tree": "e0ebe5aae3fabd439bb8a003b7dcdf5e2ead2a54",
       "version-string": "master",
       "port-version": 0
     }

--- a/versions/l-/libxml2.json
+++ b/versions/l-/libxml2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7c350610ca7e193e8f303598cf8039958537d81b",
+      "git-tree": "9adc435281d53b3906a7cc7394dfe340edeb1c51",
       "version": "2.11.9",
       "port-version": 0
     },

--- a/versions/z-/zlib.json
+++ b/versions/z-/zlib.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f546417328e7870aa6d36e809c317712f2faa076",
+      "git-tree": "3f05e04b9aededb96786a911a16193cdb711f0c9",
       "version": "1.3.1",
       "port-version": 0
     },


### PR DESCRIPTION
Update the version databases for hyperscan, libxml2, and libinjection to reflect the latest changes.