### PR TITLE
Revert multiple updates to ports and version databases

### DIFF
--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/benchmark.git
-    REF 12235e24652fc7f809373e7c11a5f73c5763fc4c
+    REPO google/benchmark
+    REF "v${VERSION}"
+    SHA512 0e91e0e5a2222d7650fd8bd9cafb2f0e7c1689cd1b87b2cc529c738db12bfef31162aa5a4da78f7b0aa7f0101dc08b626802c58d39862458f82f9fea9316ca25
     HEAD_REF main
 )
 

--- a/ports/brotli/portfile.cmake
+++ b/ports/brotli/portfile.cmake
@@ -1,7 +1,9 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/brotli.git
-    REF ed738e842d2fbdf2d6459e39267a633c4a9b2f5d
+    REPO google/brotli
+    REF v${VERSION} # v1.1.0 
+    SHA512 6eb280d10d8e1b43d22d00fa535435923c22ce8448709419d676ff47d4a644102ea04f488fc65a179c6c09fee12380992e9335bad8dfebd5d1f20908d10849d9
+    HEAD_REF master
     PATCHES
         install.patch
         fix-arm-uwp.patch

--- a/ports/bzip2/portfile.cmake
+++ b/ports/bzip2/portfile.cmake
@@ -1,8 +1,13 @@
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/bzip2.git
-    REF 6a8690fc8d26c815e798c588f796eabe9d684cf0
-    HEAD_REF master
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://sourceware.org/pub/bzip2/bzip2-${VERSION}.tar.gz"
+         "https://www.mirrorservice.org/sites/sourceware.org/pub/bzip2/bzip2-${VERSION}.tar.gz"
+    FILENAME "bzip2-${VERSION}.tar.gz"
+    SHA512 083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES fix-import-export-macros.patch
 )
 

--- a/ports/expat/portfile.cmake
+++ b/ports/expat/portfile.cmake
@@ -1,9 +1,10 @@
 string(REPLACE "." "_" REF "R_${VERSION}")
 
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libexpat.git
-    REF 2691aff4304a6d7e053199c205620136481b9dd1
+    REPO libexpat/libexpat
+    REF "${REF}"
+    SHA512 6a6c5b0f6a1b2c70715701aeab688e476943704c492a0f2f8afd7fea84615a8d9569eb2b699912676058eff6a7bbdd78b48110ed67ab0250a3d41fe8f128f4e1
     HEAD_REF master
 )
 

--- a/ports/freetype/portfile.cmake
+++ b/ports/freetype/portfile.cmake
@@ -4,10 +4,12 @@ endif()
 
 string(REPLACE "." "-" VERSION_HYPHEN "${VERSION}")
 
-vcpkg_from_git(
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/freetype.git
-    REF 42608f77f20749dd6ddc9e0536788eaad70ea4b5
+    REPO freetype/freetype
+    REF "VER-${VERSION_HYPHEN}"
+    SHA512  fccfaa15eb79a105981bf634df34ac9ddf1c53550ec0b334903a1b21f9f8bf5eb2b3f9476e554afa112a0fca58ec85ab212d674dfd853670efec876bacbe8a53
     HEAD_REF master
     PATCHES
         0003-Fix-UWP.patch

--- a/ports/gumbo/portfile.cmake
+++ b/ports/gumbo/portfile.cmake
@@ -1,10 +1,11 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_git(
-    OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/gumbo-parser.git
-    REF 8dc6ca0470097de9e4e1271e69f382c8486c4c81
-    HEAD_REF master
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO google/gumbo-parser
+  REF v0.10.1
+  SHA512  bb1fb55cd07076ab6a9f38dc14db50397dbdca9a04ace4895dfba8b8cbc09038a96e26070c09c75fa929ada2e815affe233c1e2ecd8afe2aba6201647cf277d1
+  HEAD_REF master
 )
 
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")

--- a/ports/harfbuzz/portfile.cmake
+++ b/ports/harfbuzz/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/harfbuzz.git
-    REF 9ef44a2d67ac870c1f7f671f6dc98d08a2579865
+    REPO harfbuzz/harfbuzz
+    REF ${VERSION}
+    SHA512 47817eaecaf987f8aa67dc9eb7f87c0cfc00705b192245063322a1c360501e47be20f745907302b8c497ab7d15f423fbf6d7766e437cf9871cf5c617b1590407
     HEAD_REF master
     PATCHES
         fix-win32-build.patch
@@ -91,15 +92,15 @@ vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
 if(VCPKG_TARGET_IS_WINDOWS)
-	file(GLOB PC_FILES
-		"${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc"
+	file(GLOB PC_FILES 
+		"${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc" 
 		"${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc")
-
+	
 	foreach(PC_FILE IN LISTS PC_FILES)
 		file(READ "${PC_FILE}" PC_FILE_CONTENT)
-		string(REGEX REPLACE
-			"\\$\\{prefix\}\\/lib\\/([a-zA-Z0-9\-]*)\\.lib"
-			"-l\\1" PC_FILE_CONTENT
+		string(REGEX REPLACE 
+			"\\$\\{prefix\}\\/lib\\/([a-zA-Z0-9\-]*)\\.lib" 
+			"-l\\1" PC_FILE_CONTENT 
 			"${PC_FILE_CONTENT}")
 		file(WRITE "${PC_FILE}" ${PC_FILE_CONTENT})
 	endforeach()

--- a/ports/jbig2dec/portfile.cmake
+++ b/ports/jbig2dec/portfile.cmake
@@ -1,9 +1,10 @@
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/jbig2dec.git
-    REF 1d1347e38a55e657dcc4c8f1c77bb3a26bfc9ff3
+    REPO ArtifexSoftware/jbig2dec
+    REF "${VERSION}"
+    SHA512 8b8a28b93b23e4284ca229e6c8935fd161ce5c597f7470a46ec06a3241d0ac23cf921aecdd4e0c1bd3c904591409054236f2ce25b6d8ae40db742559c7f4dbe9
     HEAD_REF master
 )
 

--- a/ports/libarchive/portfile.cmake
+++ b/ports/libarchive/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libarchive.git
-    REF b439d586f53911c84be5e380445a8a259e19114c
+    REPO libarchive/libarchive
+    REF "v${VERSION}"
+    SHA512 95c6232d178b26daa0eeba43d64ea4235aa96fa279c85fff715ac5e6cc73b2e65f276770f91c3538cb8ca989380555169497628d73e120bfa52e12f657049ff0
     HEAD_REF master
     PATCHES
         disable-warnings.patch

--- a/ports/libjpeg-turbo/portfile.cmake
+++ b/ports/libjpeg-turbo/portfile.cmake
@@ -4,10 +4,11 @@ endif()
 if(EXISTS "${CURRENT_INSTALLED_DIR}/share/ijg-libjpeg/copyright")
     message(FATAL_ERROR "Can't build ${PORT} if ijg-libjpeg is installed. Please remove ijg-libjpeg:${TARGET_TRIPLET}, and try to install ${PORT}:${TARGET_TRIPLET} again.")
 endif()
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libjpeg-turbo.git
-    REF f29eda648547b36aa594c4116c7764a6c8a079b9
+    REPO libjpeg-turbo/libjpeg-turbo
+    REF "${VERSION}"
+    SHA512 f43e1b6b9d048e29e381796c71e1c34a04c0f1c52c1f462db9f9930cfc75d69a50861be2570a6a4adc26a4183b6601300fd9d5553c06bc042f0d32fc1e408ed9
     HEAD_REF master
     PATCHES
         add-options-for-exes-docs-headers.patch
@@ -72,9 +73,9 @@ if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
         file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/jpeg-static.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/jpeg.lib")
         file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/turbojpeg-static.lib" "${CURRENT_PACKAGES_DIR}/debug/lib/turbojpeg.lib")
     endif()
-
+    
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
-
+    
     if (EXISTS "${CURRENT_PACKAGES_DIR}/share/${PORT}/libjpeg-turboTargets-debug.cmake")
         vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/libjpeg-turboTargets-debug.cmake"
             "jpeg-static${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" "jpeg${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}" IGNORE_UNCHANGED)

--- a/ports/liblzma/portfile.cmake
+++ b/ports/liblzma/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/xz.git
-    REF 9331ce4009ddc839f5191d234cc41b2d4797376d
+    REPO tukaani-project/xz
+    REF "v${VERSION}"
+    SHA512 0f814f4282c87cb74a8383199c1e55ec1bf49519daaf07f7b376cb644770b75cc9257c809b661405fcfd6cda28c54d799c67eb9e169665c35b1b87529468085e
     HEAD_REF master
     PATCHES
         build-tools.patch

--- a/ports/libpng/portfile.cmake
+++ b/ports/libpng/portfile.cmake
@@ -7,7 +7,7 @@ if ("apng" IN_LIST FEATURES)
         set(AWK_EXE_PATH "${MSYS_ROOT}/usr/bin")
         vcpkg_add_to_path("${AWK_EXE_PATH}")
     endif()
-
+    
     set(LIBPNG_APNG_PATCH_NAME "libpng-${VERSION}-apng.patch")
     vcpkg_download_distfile(LIBPNG_APNG_PATCH_ARCHIVE
         URLS "https://downloads.sourceforge.net/project/libpng-apng/libpng16/${VERSION}/${LIBPNG_APNG_PATCH_NAME}.gz"
@@ -26,10 +26,12 @@ if ("apng" IN_LIST FEATURES)
     endif()
 endif()
 
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/libpng.git
-    REF f5e92d76973a7a53f517579bc95d61483bf108c0
+    REPO glennrp/libpng
+    REF v${VERSION}
+    SHA512 c023bc7dcf3d0ea045a63204f2266b2c53b601b99d7c5f5a7b547bc9a48b205a277f699eefa47f136483f495175b226527097cd447d6b0fbceb029eb43638f63
+    HEAD_REF master
     PATCHES
         "${LIBPNG_APNG_PATCH_PATH}"
         cmake.patch

--- a/ports/lz4/portfile.cmake
+++ b/ports/lz4/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/lz4.git
-    REF ebb370ca83af193212df4dcbadcc5d87bc0de2f0
+    REPO lz4/lz4
+    REF v${VERSION}
+    SHA512 8c4ceb217e6dc8e7e0beba99adc736aca8963867bcf9f970d621978ba11ce92855912f8b66138037a1d2ae171e8e17beb7be99281fea840106aa60373c455b28
     HEAD_REF dev
     PATCHES
         target-lz4-lz4.diff

--- a/ports/openjpeg/portfile.cmake
+++ b/ports/openjpeg/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/openjpeg.git
-    REF 39e8c50a2f9bdcf36810ee3d41bcbf1cc78968ae
+    REPO uclouvain/openjpeg
+    REF "v${VERSION}"
+    SHA512 24c058b3e0710e689ba7fd6bce8a88353ce64e825b2e5bbf6b00ca3f2a2ec1e9c70a72e0252a5c89d10c537cf84d55af54bf2f16c58ca01db98c2018cf132e1a
     HEAD_REF master
     PATCHES
         third-party.diff
@@ -18,7 +19,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 )
 
 if(NOT VCPKG_TARGET_IS_WINDOWS AND "tools" IN_LIST FEATURES)
-    list(APPEND FEATURE_OPTIONS
+    list(APPEND FEATURE_OPTIONS 
         -DBUILD_JPIP_SERVER=ON
         "-DFCGI_INCLUDE_DIR=${CURRENT_INSTALLED_DIR}/include/fastcgi"
     )

--- a/ports/openssl/portfile.cmake
+++ b/ports/openssl/portfile.cmake
@@ -7,10 +7,11 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 endif()
 
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/openssl.git
-    REF 98acb6b02839c609ef5b837794e08d906d965335
+    REPO openssl/openssl
+    REF "openssl-${VERSION}"
+    SHA512 d5f78b2e9d7b7b4787c976c4f832b1448bbadf5f9d398a50ef98053f92501768d000aa73673af200568aef4c8a491442ebbee8c43556838f465d4f91dfc2b5ad
     PATCHES
         cmake-config.patch
         command-line-length.patch

--- a/ports/pugixml/portfile.cmake
+++ b/ports/pugixml/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/pugixml.git
-    REF ee86beb30e4973f5feffe3ce63bfa4fbadf72f38
+    REPO zeux/pugixml
+    REF "v${VERSION}"
+    SHA512 730d203829eb24d6e1c873f9b921ae97cf7a157fd45504151bc2e61adea5c536eaf33ff38c5ad61629b54a6686135ff1834a61102b4660fbb9ead4ecf20dfd34
     HEAD_REF master
 )
 

--- a/ports/pugixml/vcpkg.json
+++ b/ports/pugixml/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pugixml",
-  "version": "1.15",
+  "version": "1.14",
   "description": "Light-weight, simple and fast XML parser for C++ with XPath support",
   "homepage": "https://github.com/zeux/pugixml",
   "license": "MIT",

--- a/ports/xlsxio/fix-dependencies.patch
+++ b/ports/xlsxio/fix-dependencies.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8ef4d3d..b1c9f85 100644
+index 7e86706..f2bdc36 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -57,7 +57,9 @@ ELSEIF(WITH_MINIZIP_NG)
@@ -21,7 +21,7 @@ index 8ef4d3d..b1c9f85 100644
 +  FIND_PACKAGE(EXPAT NAMES expat REQUIRED)
 +  SET(EXPAT_LIBRARIES expat::expat)
  ENDIF()
- #   dependency: expatw (if wide library was requested)
+ #   dependancy: expatw (if wide library was requested)
  IF(WITH_WIDE)
 @@ -225,13 +228,13 @@ FILE(WRITE "${CMAKE_CURRENT_BINARY_DIR}/xlsxio-config.cmake.in"
  IF (@WITH_LIBZIP@)
@@ -39,12 +39,3 @@ index 8ef4d3d..b1c9f85 100644
  ENDIF()
  
  IF(@WITH_WIDE@)
-@@ -253,7 +256,7 @@ INSTALL(TARGETS ${ALLTARGETS_EXE}
-   RUNTIME DESTINATION bin
- )
- INSTALL(DIRECTORY include/
--  DESTINATION include 
-+  DESTINATION include
-   FILES_MATCHING PATTERN "xlsxio*.h"
- )
- IF(MINGW AND BUILD_SHARED)

--- a/ports/xlsxio/portfile.cmake
+++ b/ports/xlsxio/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/xlsxio.git
-    REF b968a31b5ed70e6a24504b249e4c58f2fef0d1b0
+    REPO brechtsanders/xlsxio
+    REF "${VERSION}"
+    SHA512 67b9a4e275446f3ca08e91d31f05236855e761c06ed84ea3aea8c25a7cd6729191f6c95b9efe07392775a75e2713e7ec2c6d216b8d310e7b46bee531cccba8be
     HEAD_REF master
     PATCHES
         fix-dependencies.patch

--- a/ports/xlsxio/vcpkg.json
+++ b/ports/xlsxio/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "xlsxio",
-  "version": "0.2.35",
+  "version": "0.2.34",
   "description": "Cross-platform C library for reading values from and writing values to .xlsx files",
   "homepage": "https://github.com/brechtsanders/xlsxio",
   "license": "MIT",

--- a/ports/zstd/portfile.cmake
+++ b/ports/zstd/portfile.cmake
@@ -1,7 +1,8 @@
-vcpkg_from_git(
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.sr.ok/cpp-deps/zstd.git
-    REF 794ea1b0afca0f020f4e57b6732332231fb23c70
+    REPO facebook/zstd
+    REF "v${VERSION}"
+    SHA512 ca12dffd86618ca008e1ecc79056c1129cb4e61668bf13a3cd5b2fa5c93bc9c92c80f64c1870c68b9c20009d9b3a834eac70db72242d5106125a1c53cccf8de8
     HEAD_REF dev
     PATCHES
         no-static-suffix.patch

--- a/versions/b-/benchmark.json
+++ b/versions/b-/benchmark.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "60a334832dfd7ccb16f84a1d5ea69cd45eb5d89c",
+      "git-tree": "fb5125735472f7f54342eb37ba52a8715178c9f0",
       "version-semver": "1.9.0",
       "port-version": 0
     },

--- a/versions/b-/brotli.json
+++ b/versions/b-/brotli.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "26c200531d3b10b4fd698c1b3e45e9953adb7242",
+      "git-tree": "4e5b5ae1ad26c80535c893cc0307121f0398549e",
       "version": "1.1.0",
       "port-version": 1
     },

--- a/versions/b-/bzip2.json
+++ b/versions/b-/bzip2.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "c0e5ba2c06045ab90b7231e7252f6282c11cae58",
+      "git-tree": "2d029da682847c5ebdc54e4dbea001331a02207e",
       "version-semver": "1.0.8",
       "port-version": 6
     },

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -7301,7 +7301,7 @@
       "port-version": 0
     },
     "pugixml": {
-      "baseline": "1.15",
+      "baseline": "1.14",
       "port-version": 0
     },
     "pulsar-client-cpp": {

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9837,7 +9837,7 @@
       "port-version": 4
     },
     "xlsxio": {
-      "baseline": "0.2.35",
+      "baseline": "0.2.34",
       "port-version": 0
     },
     "xmlsec": {

--- a/versions/e-/expat.json
+++ b/versions/e-/expat.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "95305bf168b5ece9970a58c79f0cbf3afbd20f06",
+      "git-tree": "97dd7e516104f330e1bb5eafff10852211dbd2df",
       "version": "2.6.4",
       "port-version": 0
     },

--- a/versions/f-/freetype.json
+++ b/versions/f-/freetype.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "9bab58b204db828a6be680909beffbc4db88377d",
+      "git-tree": "8a2c633dcc14eaabdb31cf4637242f4e3c2f3fa2",
       "version": "2.13.3",
       "port-version": 0
     },

--- a/versions/g-/gumbo.json
+++ b/versions/g-/gumbo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "e1141282de3848e86b0f75c115783d4a90c6ac26",
+      "git-tree": "b0b57c7286bdadcc64d0e4b2f5b5aca951bb1749",
       "version": "0.10.1",
       "port-version": 6
     },

--- a/versions/h-/harfbuzz.json
+++ b/versions/h-/harfbuzz.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "55cf9f6d8c704cc263ffbc256f490e03ee03fd39",
+      "git-tree": "0bf3419dd2362d61aa7b93eceba27acf0a7b826c",
       "version": "10.1.0",
       "port-version": 0
     },

--- a/versions/j-/jbig2dec.json
+++ b/versions/j-/jbig2dec.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4a536900d73057be4728241a96bdf6f4245a3c3e",
+      "git-tree": "d34cf9e520c5866b3facce621e46e438eb1b31c5",
       "version": "0.20",
       "port-version": 0
     },

--- a/versions/l-/libarchive.json
+++ b/versions/l-/libarchive.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "603c026014b0cdfeb1bad26383923f15c1e1158c",
+      "git-tree": "273f56c8b692d2fb25364dd5b117f22449578ffe",
       "version": "3.7.7",
       "port-version": 2
     },

--- a/versions/l-/libjpeg-turbo.json
+++ b/versions/l-/libjpeg-turbo.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "1be4dcfe509e1b06ec364fab762ae536f4c4f888",
+      "git-tree": "fbedc8ef954f9951c7d169c9bac3f9534b4b2c77",
       "version": "3.0.4",
       "port-version": 0
     },

--- a/versions/l-/liblzma.json
+++ b/versions/l-/liblzma.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "5cbf47279081673172cb9db004b81cce075a1f26",
+      "git-tree": "b5e5694620b41a4d668390e5d14fa2326e0afdc3",
       "version": "5.6.3",
       "port-version": 0
     },

--- a/versions/l-/libpng.json
+++ b/versions/l-/libpng.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "7ce5aebd6f72aac617139fea0c2de05712f056b0",
+      "git-tree": "bda480fe3c3cef1113fe8bfdecda127a5b3b2a77",
       "version": "1.6.44",
       "port-version": 0
     },

--- a/versions/l-/lz4.json
+++ b/versions/l-/lz4.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "2c94ab47fb1c9da6364568e6468c8df6880ec4ea",
+      "git-tree": "4f01eec10f515a428e914107c5188366380f8dd9",
       "version": "1.10.0",
       "port-version": 0
     },

--- a/versions/o-/openjpeg.json
+++ b/versions/o-/openjpeg.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "f1ba5e430618b3d3036b89b34ae06899541d3f32",
+      "git-tree": "1b99f9bb2f9f35e4bb3c6c83ff08e06a930ce72a",
       "version": "2.5.2",
       "port-version": 1
     },

--- a/versions/o-/openssl.json
+++ b/versions/o-/openssl.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "d097263944743a2e6e639ca8b5523e456809758c",
+      "git-tree": "ce504a83eb9627d54f1cffdb497a6bf5bd970d18",
       "version": "3.4.0",
       "port-version": 0
     },

--- a/versions/p-/pugixml.json
+++ b/versions/p-/pugixml.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "13b31f1ef9dca2fa93e1fef216d087169a888a45",
-      "version": "1.15",
-      "port-version": 0
-    },
-    {
       "git-tree": "6e38344aea6e7529afde3895e0885ed5cb0c0542",
       "version": "1.14",
       "port-version": 0

--- a/versions/x-/xlsxio.json
+++ b/versions/x-/xlsxio.json
@@ -1,11 +1,6 @@
 {
   "versions": [
     {
-      "git-tree": "ffdde3489b95b5d1e033cf8fb7893c520a8760eb",
-      "version": "0.2.35",
-      "port-version": 0
-    },
-    {
       "git-tree": "fd38fc13e5e2b58d149261e8d692e1df7f93b88a",
       "version": "0.2.34",
       "port-version": 0

--- a/versions/z-/zstd.json
+++ b/versions/z-/zstd.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "git-tree": "4ff31879243f8e9e91a474eb4474e99afedfa231",
+      "git-tree": "796171d4d359b6786b8e1380fb6da8e677a9087b",
       "version": "1.5.6",
       "port-version": 0
     },


### PR DESCRIPTION
Revert recent updates to various ports and their version databases to restore previous states. This includes libraries such as lzma, benchmark, zstd, and others.